### PR TITLE
Fix the WHMCS total does not match with Xendit Total

### DIFF
--- a/modules/gateways/xendit/lib/Link.php
+++ b/modules/gateways/xendit/lib/Link.php
@@ -53,7 +53,7 @@ class Link extends ActionBase
             'description' => $params["description"],
             'items' => $this->extractItems($invoice),
             'fees' => array(['type' => 'Payment Fee', 'value' => (float)$params['paymentfee']]),
-            'amount' => $params['amount'] + (float)$params['paymentfee'],
+            'amount' => $this->roundUpTotal($params['amount'] + (float)$params['paymentfee']),
             'client_type' => 'INTEGRATION',
             'platform_callback_url' => $params["systemurl"] . $this->callbackUrl,
             'success_redirect_url' => $this->invoiceUrl($params['invoiceid'], $params['systemurl']),

--- a/modules/gateways/xendit/tests/WHMCSModuleTest.php
+++ b/modules/gateways/xendit/tests/WHMCSModuleTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Xendit\Tests;
 
 /**
@@ -46,5 +47,65 @@ class WHMCSModuleTest extends TestCase
         $this->assertArrayHasKey('xenditPublicKey', $result);
         $this->assertArrayHasKey('xenditSecretKey', $result);
         $this->assertArrayHasKey('xenditExternalPrefix', $result);
+    }
+
+    /**
+     * @return array
+     */
+    public function totalDataProvider(): array
+    {
+        return [
+            [
+                "xenditTotal" => 1000,
+                "whmcsTotal" => 999.9555555,
+                "expectTotal" => 999.9555555
+            ],
+            [
+                "xenditTotal" => 1000,
+                "whmcsTotal" => 999,
+                "expectTotal" => 1000
+            ],
+            [
+                "xenditTotal" => 9999,
+                "whmcsTotal" => 9999.5,
+                "expectTotal" => 9999
+            ],
+            [
+                "xenditTotal" => 9999,
+                "whmcsTotal" => 9998,
+                "expectTotal" => 9999
+            ],
+            [
+                "xenditTotal" => 20000,
+                "whmcsTotal" => 19999.01,
+                "expectTotal" => 19999.01
+            ]
+        ];
+    }
+
+    /**
+     * Test the round up total should have no decimal
+     */
+    public function testRoundUpTotalNotHasDecimal()
+    {
+        $actionBase = new \Xendit\Lib\ActionBase();
+
+        foreach ($this->totalDataProvider() as $total) {
+            $roundedTotal = $actionBase->roundUpTotal($total["whmcsTotal"]);
+            $this->assertTrue($roundedTotal == ceil($total["whmcsTotal"]));
+        }
+    }
+
+    /**
+     * Test the callback paid total
+     */
+    public function testCallbackPaidTotal()
+    {
+        $actionBase = new \Xendit\Lib\ActionBase();
+
+        foreach ($this->totalDataProvider() as $total) {
+            $this->assertIsFloat($actionBase->extractPaidAmount($total["xenditTotal"], $total["whmcsTotal"]));
+            $this->assertEquals($total["expectTotal"], $actionBase->extractPaidAmount($total["xenditTotal"], $total["whmcsTotal"]));
+        }
     }
 }


### PR DESCRIPTION
## Description

- Fix the WHMCS total does not match with Xendit Total
- Implement function to compare total WHMCS and Xendit on update WHMCS order status
- Add unit tests

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] General improvement (non-breaking feature that might not necessarily impact customer)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code (if necessary), particularly in hard-to-understand areas
- [ ] My changes generate no new **vulnerabilities**
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshot

![Screenshot from 2022-04-21 16-57-40](https://user-images.githubusercontent.com/5335952/164430498-2cbccbbf-85ad-40fc-9cba-447b6fb84a33.png)

